### PR TITLE
fixed FullMath.sol solc 0.8

### DIFF
--- a/contracts/libraries/FullMath.sol
+++ b/contracts/libraries/FullMath.sol
@@ -5,7 +5,7 @@ pragma solidity >= 0.7.0;
 // license is CC-BY-4.0
 library FullMath {
     function fullMul(uint256 x, uint256 y) internal pure returns (uint256 l, uint256 h) {
-		uint256 mm = mulmod(x, y, type(uint256).max);
+	uint256 mm = mulmod(x, y, type(uint256).max);
         l = x * y;
         h = mm - l;
         if (mm < l) h -= 1;
@@ -16,10 +16,10 @@ library FullMath {
         uint256 h,
         uint256 d
     ) private pure returns (uint256) {
-	    uint256 pow2 = d & (~d + 1);
+	uint256 pow2 = d & (~d + 1);
         d /= pow2;
         l /= pow2;
-		l += h * ((~pow2 + 1) / pow2 + 1);
+	l += h * ((~pow2 + 1) / pow2 + 1);
         uint256 r = 1;
         r *= 2 - d * r;
         r *= 2 - d * r;


### PR DESCRIPTION
fixed v0.8 solc issue.
1) Using (type(T).max) is gas efficient and readable https://solidity.readthedocs.io/en/v0.6.8/types.html#integers . Solidity 0.8c does not support uint256(-1).
2) v0.8 forbids the negation of unsigned integers.